### PR TITLE
Fix React toggle-all visibility and add test

### DIFF
--- a/cypress/integration/spec.js
+++ b/cypress/integration/spec.js
@@ -968,6 +968,26 @@ Cypress._.times(N, () => {
           .contains(selectors.filterItems, 'Completed')
           .should('have.class', 'selected')
       })
+
+      if (framework === 'react') {
+        it('should keep toggle all visible and unchecked on completed route until all todos are done', function () {
+          cy.get('@todos').eq(0).find('.toggle').check()
+
+          cy.contains(selectors.filterItems, 'Completed').click()
+          cy.hash().should('eq', '#/completed')
+          cy
+            .get(selectors.toggleAll)
+            .should('be.visible')
+            .and('not.be.checked')
+
+          cy.contains(selectors.filterItems, 'All').click()
+          cy.get('@todos').eq(1).find('.toggle').check()
+          cy.get('@todos').eq(2).find('.toggle').check()
+          cy.contains(selectors.filterItems, 'Completed').click()
+          cy.hash().should('eq', '#/completed')
+          cy.get(selectors.toggleAll).should('be.checked')
+        })
+      }
     })
   })
 })

--- a/examples/react/src/todo/components/main.jsx
+++ b/examples/react/src/todo/components/main.jsx
@@ -27,9 +27,16 @@ export function Main({ todos, dispatch }) {
 
     return (
         <main className="main" data-testid="main">
-            {visibleTodos.length > 0 ? (
+            {todos.length > 0 ? (
                 <div className="toggle-all-container">
-                    <input className="toggle-all" type="checkbox" id="toggle-all" data-testid="toggle-all" checked={visibleTodos.every((todo) => todo.completed)} onChange={toggleAll} />
+                    <input
+                        className="toggle-all"
+                        type="checkbox"
+                        id="toggle-all"
+                        data-testid="toggle-all"
+                        checked={todos.length > 0 && todos.every((todo) => todo.completed)}
+                        onChange={toggleAll}
+                    />
                     <label className="toggle-all-label" htmlFor="toggle-all">
                         Toggle All Input
                     </label>


### PR DESCRIPTION
## Summary
- render the React toggle-all control whenever any todos exist
- compute the toggle-all checked state against all todos so hidden items keep it unchecked
- add a React-specific Cypress test ensuring toggle-all stays visible and unchecked on the completed route until everything is done

## Testing
- `CYPRESS_framework=react npm test` *(fails: run-p missing because dependencies could not be installed due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68cb42810af88320b86dd79436091cf0