### PR TITLE
chore: update express dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "test:all": "node tests/cya.js"
   },
   "dependencies": {
-    "express": "^4.10.0"
+    "express": "^4.16.3"
   },
   "devDependencies": {
     "@bahmutov/print-env": "^1.0.1",


### PR DESCRIPTION
## Summary
- raise the express dependency from ^4.10.0 to ^4.16.3 to match the locked version

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d3207b1160832091e4f775176443a3